### PR TITLE
bump k8s client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <fabric8.openshift-client.version>4.3.1</fabric8.openshift-client.version>
+        <fabric8.openshift-client.version>4.4.2</fabric8.openshift-client.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <prometheus.metrics.version>0.6.0</prometheus.metrics.version>
         <guava.version>23.0</guava.version>
@@ -133,6 +133,11 @@
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-core</artifactId>
+                <version>${quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
align the version of openshift client (that has dependency on k8s client) with the version that's used by apache spark