### PR TITLE
Bump fabric8 client version to 4.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <fabric8.kubernetes-client.version>4.7.1</fabric8.kubernetes-client.version>
+        <fabric8.kubernetes-client.version>4.10.3</fabric8.kubernetes-client.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <prometheus.metrics.version>0.8.1</prometheus.metrics.version>
         <guava.version>23.0</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.radanalytics</groupId>
     <artifactId>operator-parent-pom</artifactId>
-    <version>0.3.26</version>
+    <version>0.3.27-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Operator Parent POM</name>
     <description>parent pom.xml file that is supposed to be reused as parent pom in custom operators</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.radanalytics</groupId>
     <artifactId>operator-parent-pom</artifactId>
-    <version>0.3.26-SNAPSHOT</version>
+    <version>0.3.26</version>
     <packaging>pom</packaging>
     <name>Operator Parent POM</name>
     <description>parent pom.xml file that is supposed to be reused as parent pom in custom operators</description>


### PR DESCRIPTION
This change is needed to work on kubernetes version 1.19+

The fabric8 client in use (4.7.1) throws an error while trying to parse the response from a "list CRD" call to the kubernetes master. The 4.10.3 client works both with kube 1.18 and 1.19.